### PR TITLE
Add env var prints

### DIFF
--- a/async_double_buffer.cpp
+++ b/async_double_buffer.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <thread>
 #include <iostream>
+#include <cstdlib>
 
 int main(int argc, char** argv) {
     MPI_Init(&argc, &argv);
@@ -10,6 +11,17 @@ int main(int argc, char** argv) {
     int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    const char* env_vars[] = {
+        "MSMPI_SHM_EAGER_LIMIT",
+        "MSMPI_ND_EAGER_LIMIT",
+        "MSMPI_SOCKET_EAGER_LIMIT"
+    };
+    for (const char* var : env_vars) {
+        const char* val = std::getenv(var);
+        std::cout << "Rank " << rank << " " << var << "="
+                  << (val ? val : "(unset)") << std::endl;
+    }
 
     if (size < 2) {
         if (rank == 0) {


### PR DESCRIPTION
## Summary
- print MS-MPI eager limit environment variables at startup

## Testing
- `g++ async_double_buffer.cpp -o async_double_buffer -lmpi` *(fails: mpi.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559be846c08325831dac64b25b9494